### PR TITLE
fix: resolve worker.d.ts syntax error

### DIFF
--- a/bridge/stdlib/worker/worker.d.ts
+++ b/bridge/stdlib/worker/worker.d.ts
@@ -1,10 +1,12 @@
 // MODULE: typego:worker
 declare module "typego:worker" {
-    export class Worker {
-        constructor(scriptPath: string);
+    export interface Worker {
         postMessage(msg: any): void;
         terminate(): void;
         onmessage: (msg: { data: any }) => void;
     }
+    export var Worker: {
+        new(scriptPath: string): Worker;
+    };
 }
 // END: typego:worker


### PR DESCRIPTION
Fixes a syntax error in `worker.d.ts` where `export class` was used in an ambient context. Replaces it with the `interface` + `var` pattern.