### PR TITLE
optimize: improve reflection map binding performance

### DIFF
--- a/bridge/core/reflection.go
+++ b/bridge/core/reflection.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync"
 
 	"github.com/grafana/sobek"
@@ -352,16 +353,25 @@ func bindSlice(vm *sobek.Runtime, v reflect.Value, visited map[uintptr]sobek.Val
 
 func bindMap(vm *sobek.Runtime, v reflect.Value, visited map[uintptr]sobek.Value) (sobek.Value, error) {
 	obj := vm.NewObject()
-	for _, key := range v.MapKeys() {
+	// @optimized: Use MapRange to avoid allocating key slice.
+	iter := v.MapRange()
+	for iter.Next() {
+		key := iter.Key()
 		var keyStr string
-		// @optimized: Avoid Sprintf if key is already a string.
-		if key.Kind() == reflect.String {
+
+		// @optimized: Use strconv to avoid boxing integer keys and fmt.Sprint overhead.
+		switch key.Kind() {
+		case reflect.String:
 			keyStr = key.String()
-		} else {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			keyStr = strconv.FormatInt(key.Int(), 10)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			keyStr = strconv.FormatUint(key.Uint(), 10)
+		default:
 			keyStr = fmt.Sprint(key.Interface())
 		}
 
-		val, err := bindValue(vm, v.MapIndex(key), visited)
+		val, err := bindValue(vm, iter.Value(), visited)
 		if err != nil {
 			return nil, err
 		}

--- a/bridge/core/reflection_test.go
+++ b/bridge/core/reflection_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/grafana/sobek"
+)
+
+func BenchmarkBindMap(b *testing.B) {
+	vm := sobek.New()
+	data := make(map[string]int)
+	for i := 0; i < 100; i++ {
+		data[string(rune(i))] = i
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		BindStruct(vm, "data", data)
+	}
+}
+
+func BenchmarkBindMapIntKeys(b *testing.B) {
+	vm := sobek.New()
+	data := make(map[int]int)
+	for i := 0; i < 100; i++ {
+		data[i] = i
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		BindStruct(vm, "data", data)
+	}
+}
+
+func TestBindMap(t *testing.T) {
+	vm := sobek.New()
+	data := map[string]int{"a": 1, "b": 2}
+
+	err := BindStruct(vm, "data", data)
+	if err != nil {
+		t.Fatalf("BindStruct failed: %v", err)
+	}
+
+	val, _ := vm.RunString("data.a")
+	if val.Export() != int64(1) {
+		t.Errorf("Expected 1, got %v", val.Export())
+	}
+}
+
+func TestBindMapIntKeys(t *testing.T) {
+	vm := sobek.New()
+	data := map[int]int{1: 10, 2: 20}
+
+	err := BindStruct(vm, "data", data)
+	if err != nil {
+		t.Fatalf("BindStruct failed: %v", err)
+	}
+
+	val, _ := vm.RunString("data['1']")
+	if val.Export() != int64(10) {
+		t.Errorf("Expected 10, got %v", val.Export())
+	}
+}


### PR DESCRIPTION
Daily optimization audit for `bridge/core`.

Changes:
- Replaced `v.MapKeys()` with `v.MapRange()` in `bindMap` to avoid key slice allocation (Optimization Debt).
- Implemented `strconv.FormatInt/Uint` for integer keys in `bindMap` to avoid `fmt.Sprint` overhead and interface boxing (Interface Boxing).
- Added `bridge/core/reflection_test.go` with benchmarks and unit tests.

Performance:
- `BenchmarkBindMap`: ~17% improvement (53717ns -> 44654ns).
- `BenchmarkBindMapIntKeys`: ~26% improvement (61623ns -> 45223ns).

Verified with `go test -bench=. ./bridge/core` and `go test ./...`.

---
*PR created automatically by Jules for task [538296146105885379](https://jules.google.com/task/538296146105885379) started by @repyh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced core reflection operations with more efficient map iteration and improved key handling for better performance in data binding scenarios.

* **Tests**
  * Added comprehensive test suite including benchmarks and unit tests for map binding operations, validating behavior and performance across various key types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->