### PR TITLE
chore: sanitize redundant comments and AI-fluff

### DIFF
--- a/bridge/core/arraybuffer.go
+++ b/bridge/core/arraybuffer.go
@@ -4,7 +4,6 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// ToArrayBuffer converts a Go byte slice to a JavaScript ArrayBuffer.
 // The returned ArrayBuffer is a copy of the original data, so modifications
 // in JavaScript will not affect the Go slice.
 //
@@ -14,7 +13,6 @@ func ToArrayBuffer(vm *sobek.Runtime, data []byte) sobek.Value {
 	return vm.ToValue(vm.NewArrayBuffer(data))
 }
 
-// MapSharedBuffer exposes a Go byte slice as a global JavaScript TypedArray.
 // The backing memory is shared between Go and JavaScript, meaning modifications
 // from either side are immediately visible to the other.
 //

--- a/bridge/core/reflection.go
+++ b/bridge/core/reflection.go
@@ -8,29 +8,24 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// Binding represents a Go struct that has been bound to the JavaScript runtime.
 type Binding struct {
 	Name   string
 	Target interface{}
 }
 
-// methodInfo holds metadata about an exported method to avoid repeated reflection lookups.
 type methodInfo struct {
 	Name  string
 	Index int
 }
 
-// fieldInfo holds metadata about an exported field to avoid repeated reflection lookups.
 type fieldInfo struct {
 	Index     int
 	Name      string
 	Anonymous bool
 }
 
-// cache for struct method metadata: reflect.Type -> []methodInfo
 var typeMethodCache sync.Map
 
-// cache for struct field metadata: reflect.Type -> []fieldInfo
 var typeFieldCache sync.Map
 
 // BindStruct exposes a Go struct to JavaScript with full field and method access.
@@ -43,7 +38,6 @@ func BindStruct(vm *sobek.Runtime, name string, s interface{}) error {
 	return vm.GlobalObject().Set(name, obj)
 }
 
-// bindValue recursively converts a Go value to a JavaScript value.
 // The visited map prevents infinite loops for circular references.
 func bindValue(vm *sobek.Runtime, v reflect.Value, visited map[uintptr]sobek.Value) (sobek.Value, error) {
 	if !v.IsValid() {

--- a/bridge/intrinsics/buffer.go
+++ b/bridge/intrinsics/buffer.go
@@ -6,7 +6,6 @@ import (
 
 // Buffer intrinsics provide high-performance byte array operations.
 
-// BufferAlloc implements Buffer.alloc(size)
 func (r *Registry) BufferAlloc(call sobek.FunctionCall) sobek.Value {
 	size := 0
 	if len(call.Arguments) > 0 {
@@ -21,7 +20,6 @@ func (r *Registry) BufferAlloc(call sobek.FunctionCall) sobek.Value {
 	return tArray
 }
 
-// BufferFrom implements Buffer.from(data, encoding)
 func (r *Registry) BufferFrom(call sobek.FunctionCall) sobek.Value {
 	if len(call.Arguments) == 0 {
 		return r.vm.ToValue([]byte{})

--- a/bridge/intrinsics/globals.go
+++ b/bridge/intrinsics/globals.go
@@ -37,13 +37,9 @@ const EncodingShimJS = `
 // EnableGlobals injects all environment globals into the VM.
 // This replaces the legacy polyfills package.
 func (r *Registry) EnableGlobals() {
-	// 1. Native backing intrinsics (already set in Enable)
-
-	// 2. JS Shims for Standard APIs
 	_, _ = r.vm.RunString(EncodingShimJS)
 	_, _ = r.vm.RunString(BufferShimJS)
 
-	// 3. Environment Globals
 	r.EnableProcess()
 	r.EnableTimers()
 }

--- a/bridge/intrinsics/intrinsics.go
+++ b/bridge/intrinsics/intrinsics.go
@@ -7,7 +7,6 @@ import (
 	"github.com/repyh/typego/eventloop"
 )
 
-// Registry holds references needed for intrinsics
 type Registry struct {
 	vm           *sobek.Runtime
 	currentScope *scopeState

--- a/bridge/intrinsics/process.go
+++ b/bridge/intrinsics/process.go
@@ -33,23 +33,18 @@ func (r *Registry) EnableProcess() {
 		}
 	}
 
-	// Force color
 	_ = env.Set("FORCE_COLOR", "1")
 	_ = proc.Set("env", env)
 
-	// process.platform
 	_ = proc.Set("platform", runtime.GOOS)
 
-	// process.cwd()
 	_ = proc.Set("cwd", func(call sobek.FunctionCall) sobek.Value {
 		wd, _ := os.Getwd()
 		return r.vm.ToValue(wd)
 	})
 
-	// process.argv
 	_ = proc.Set("argv", os.Args)
 
-	// process.version
 	_ = proc.Set("version", runtime.Version())
 
 	_ = r.vm.Set("process", proc)

--- a/bridge/modules/net/helpers.go
+++ b/bridge/modules/net/helpers.go
@@ -2,7 +2,6 @@ package http
 
 import "encoding/json"
 
-// toJSON converts a Go value to a JSON string
 func toJSON(v interface{}) (string, error) {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/bridge/modules/net/server.go
+++ b/bridge/modules/net/server.go
@@ -85,14 +85,12 @@ func (s *Server) Close(timeout time.Duration) error {
 func (s *Server) wrapRequest(r *http.Request) sobek.Value {
 	req := s.vm.NewObject()
 
-	// Basic properties
 	_ = req.Set("method", r.Method)
 	_ = req.Set("url", r.URL.String())
 	_ = req.Set("path", r.URL.Path)
 	_ = req.Set("host", r.Host)
 	_ = req.Set("proto", r.Proto)
 
-	// Query parameters
 	query := s.vm.NewObject()
 	for k, v := range r.URL.Query() {
 		if len(v) == 1 {
@@ -103,7 +101,6 @@ func (s *Server) wrapRequest(r *http.Request) sobek.Value {
 	}
 	_ = req.Set("query", query)
 
-	// Headers
 	headers := s.vm.NewObject()
 	for k, v := range r.Header {
 		if len(v) == 1 {
@@ -202,7 +199,6 @@ func (s *Server) wrapResponse(w http.ResponseWriter, r *http.Request) sobek.Valu
 		return sobek.Undefined()
 	})
 
-	// Redirect
 	_ = res.Set("redirect", func(call sobek.FunctionCall) sobek.Value {
 		url := call.Argument(0).String()
 		code := 302

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -90,7 +90,6 @@ func Compile(entryPoint string, virtualModules map[string]string) (*Result, erro
 						case "go:crypto":
 							content = "const c = (globalThis as any).__go_crypto__; export const Sha256 = c.Sha256; export const Sha512 = c.Sha512; export const HmacSha256 = c.HmacSha256; export const HmacSha256Verify = c.HmacSha256Verify; export const RandomBytes = c.RandomBytes; export const Uuid = c.Uuid;"
 
-						// TypeGo Stdlib
 						case "typego:memory":
 							content = "const m = (globalThis as any).__typego_memory__; export const makeShared = m.makeShared; export const stats = m.stats; export const ptr = m.ptr;"
 						case "typego:worker":
@@ -125,7 +124,6 @@ func Compile(entryPoint string, virtualModules map[string]string) (*Result, erro
 		res.JS = string(result.OutputFiles[0].Contents)
 	}
 
-	// Save to cache
 	if len(virtualModules) == 0 {
 		_ = SaveCache(entryPoint, res)
 	}

--- a/internal/linker/fetcher.go
+++ b/internal/linker/fetcher.go
@@ -6,12 +6,10 @@ import (
 	"os/exec"
 )
 
-// Fetcher handles downloading remote Go modules
 type Fetcher struct {
 	TempDir string
 }
 
-// NewFetcher creates a new Fetcher in a temporary directory
 func NewFetcher() (*Fetcher, error) {
 	tempDir, err := os.MkdirTemp("", "typego-fetcher-*")
 	if err != nil {
@@ -28,7 +26,6 @@ func NewFetcher() (*Fetcher, error) {
 	return &Fetcher{TempDir: tempDir}, nil
 }
 
-// Get downloading a package version using 'go get'
 func (f *Fetcher) Get(pkgPath string) error {
 	cmd := exec.Command("go", "get", pkgPath)
 	cmd.Dir = f.TempDir
@@ -38,7 +35,6 @@ func (f *Fetcher) Get(pkgPath string) error {
 	return nil
 }
 
-// Cleanup removes the temporary directory
 func (f *Fetcher) Cleanup() {
 	os.RemoveAll(f.TempDir)
 }

--- a/internal/linker/generator.go
+++ b/internal/linker/generator.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 )
 
-// Binds both top-level functions and exported structs.
 func GenerateShim(info *PackageInfo, variableName string) string {
 	var sb strings.Builder
 
@@ -44,16 +43,13 @@ func GenerateTypes(info *PackageInfo) string {
 	sb.WriteString(fmt.Sprintf("// MODULE: go:%s\n", info.ImportPath))
 	sb.WriteString(fmt.Sprintf("declare module \"go:%s\" {\n", info.ImportPath))
 
-	// Collect imports
 	imports := make(map[string]map[string]bool) // pkgPath -> typeName -> bool
 	for _, st := range info.Structs {
-		// Collect from fields
 		for _, field := range st.Fields {
 			if field.ImportPath != "" && field.ImportPath != info.ImportPath {
 				collectImport(imports, field.ImportPath, field.Type)
 			}
 		}
-		// Collect from embeds
 		for _, embed := range st.Embeds {
 			if embed.ImportPath != "" && embed.ImportPath != info.ImportPath {
 				collectImport(imports, embed.ImportPath, embed.Name)
@@ -61,7 +57,6 @@ func GenerateTypes(info *PackageInfo) string {
 		}
 	}
 
-	// Generate import statements
 	for pkgPath, types := range imports {
 		var typeList []string
 		for t := range types {

--- a/internal/linker/inspector.go
+++ b/internal/linker/inspector.go
@@ -183,7 +183,6 @@ func parseTypeDecl(decl *ast.GenDecl, structMap map[string]*ExportedStruct, pkgP
 			Doc:         strings.TrimSpace(decl.Doc.Text()),
 		}
 
-		// Capture Generic Type Parameters
 		if ts.TypeParams != nil {
 			for _, param := range ts.TypeParams.List {
 				for _, name := range param.Names {
@@ -201,7 +200,6 @@ func parseTypeDecl(decl *ast.GenDecl, structMap map[string]*ExportedStruct, pkgP
 					goType := types.ExprString(field.Type)
 					cleanType := strings.TrimPrefix(goType, "*")
 
-					// Resolve import path for embedded type
 					var importPath string
 					if info != nil {
 						if t, ok := info.Types[field.Type]; ok {
@@ -235,7 +233,6 @@ func parseTypeDecl(decl *ast.GenDecl, structMap map[string]*ExportedStruct, pkgP
 						continue
 					}
 
-					// Resolve import path
 					var importPath string
 					if info != nil {
 						if t, ok := info.Types[field.Type]; ok {


### PR DESCRIPTION
Performed a comment audit to remove redundant, obvious, and filler comments across the codebase.
- Removed restatements of function names and basic syntax explanations.
- Removed AI-generated conversational filler.
- Preserved architectural decision records, edge case explanations, and optimization notes.
- Touched files in `bridge/core`, `bridge/intrinsics`, `bridge/modules`, `internal/linker`, and `compiler`.

---
*PR created automatically by Jules for task [12082185982223576052](https://jules.google.com/task/12082185982223576052) started by @repyh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed non-essential internal comments across multiple modules for cleaner source code.

* **Bug Fixes**
  * Enhanced error handling and reporting in the dependency fetching process with detailed output on failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->