### PR TITLE
chore: sanitize redundant comments and AI-fluff

### DIFF
--- a/bridge/core/reflection.go
+++ b/bridge/core/reflection.go
@@ -8,19 +8,16 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// Binding represents a Go struct that has been bound to the JavaScript runtime.
 type Binding struct {
 	Name   string
 	Target interface{}
 }
 
-// methodInfo holds metadata about an exported method to avoid repeated reflection lookups.
 type methodInfo struct {
 	Name  string
 	Index int
 }
 
-// fieldInfo holds metadata about an exported field to avoid repeated reflection lookups.
 type fieldInfo struct {
 	Index     int
 	Name      string
@@ -43,7 +40,6 @@ func BindStruct(vm *sobek.Runtime, name string, s interface{}) error {
 	return vm.GlobalObject().Set(name, obj)
 }
 
-// bindValue recursively converts a Go value to a JavaScript value.
 // The visited map prevents infinite loops for circular references.
 func bindValue(vm *sobek.Runtime, v reflect.Value, visited map[uintptr]sobek.Value) (sobek.Value, error) {
 	if !v.IsValid() {

--- a/bridge/intrinsics/concurrency.go
+++ b/bridge/intrinsics/concurrency.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// Go implements the typego.go() intrinsic.
 func (r *Registry) Go(call sobek.FunctionCall) sobek.Value {
 	if len(call.Arguments) < 1 {
 		panic(r.vm.NewGoError(newPanicError("go requires a function to execute")))
@@ -27,7 +26,6 @@ func (r *Registry) Go(call sobek.FunctionCall) sobek.Value {
 			}
 		}()
 
-		// Execute the function in the VM
 		// NOTE: Sobek is NOT thread-safe for concurrent access to the SAME VM.
 		// We use the Registry's VMLock to ensure only one goroutine (or main thread) executes JS at a time.
 		r.VMLock.Lock()
@@ -42,7 +40,6 @@ func (r *Registry) Go(call sobek.FunctionCall) sobek.Value {
 	return sobek.Undefined()
 }
 
-// Chan represents a bridged Go channel.
 type Chan struct {
 	ch chan sobek.Value
 }
@@ -68,7 +65,6 @@ func (c *Chan) Close(call sobek.FunctionCall) sobek.Value {
 	return sobek.Undefined()
 }
 
-// MakeChan implements makeChan(size)
 func (r *Registry) MakeChan(call sobek.FunctionCall) sobek.Value {
 	size := 0
 	if len(call.Arguments) > 0 {
@@ -88,7 +84,6 @@ func (r *Registry) MakeChan(call sobek.FunctionCall) sobek.Value {
 	return obj
 }
 
-// Select implements select([{ chan, send, recv, default }])
 func (r *Registry) Select(call sobek.FunctionCall) sobek.Value {
 	if len(call.Arguments) < 1 {
 		return sobek.Undefined()
@@ -104,7 +99,6 @@ func (r *Registry) Select(call sobek.FunctionCall) sobek.Value {
 		caseObj := casesArr.Get(fmt.Sprintf("%d", i)).ToObject(r.vm)
 		caseObjs = append(caseObjs, caseObj)
 
-		// 1. Default case
 		if defValue := caseObj.Get("default"); defValue != nil && !sobek.IsUndefined(defValue) {
 			selectCases = append(selectCases, reflect.SelectCase{
 				Dir: reflect.SelectDefault,
@@ -112,7 +106,6 @@ func (r *Registry) Select(call sobek.FunctionCall) sobek.Value {
 			continue
 		}
 
-		// 2. Channel operation
 		chWrapper := caseObj.Get("chan")
 		if chWrapper == nil || sobek.IsUndefined(chWrapper) {
 			continue
@@ -131,7 +124,6 @@ func (r *Registry) Select(call sobek.FunctionCall) sobek.Value {
 
 		chValue := reflect.ValueOf(c.ch)
 
-		// Determine Direction
 		if sendVal := caseObj.Get("send"); sendVal != nil && !sobek.IsUndefined(sendVal) {
 			selectCases = append(selectCases, reflect.SelectCase{
 				Dir:  reflect.SelectSend,
@@ -157,7 +149,6 @@ func (r *Registry) Select(call sobek.FunctionCall) sobek.Value {
 
 	chosenObj := caseObjs[chosen]
 
-	// Handle Result
 	if selectCases[chosen].Dir == reflect.SelectRecv {
 		recvVal := recv.Interface().(sobek.Value)
 		if recvCb := chosenObj.Get("recv"); recvCb != nil && !sobek.IsUndefined(recvCb) {

--- a/bridge/intrinsics/encoding.go
+++ b/bridge/intrinsics/encoding.go
@@ -8,7 +8,6 @@ import (
 
 // Encoding intrinsics provide high-performance string/byte conversion.
 
-// Encode implements TextEncoder.prototype.encode
 func (r *Registry) Encode(call sobek.FunctionCall) sobek.Value {
 	var bytes []byte
 	if len(call.Arguments) > 0 {
@@ -26,7 +25,6 @@ func (r *Registry) Encode(call sobek.FunctionCall) sobek.Value {
 	return tArray
 }
 
-// Decode implements TextDecoder.prototype.decode
 func (r *Registry) Decode(call sobek.FunctionCall) sobek.Value {
 	if len(call.Arguments) == 0 {
 		return r.vm.ToValue("")

--- a/bridge/intrinsics/intrinsics.go
+++ b/bridge/intrinsics/intrinsics.go
@@ -7,7 +7,6 @@ import (
 	"github.com/repyh/typego/eventloop"
 )
 
-// Registry holds references needed for intrinsics
 type Registry struct {
 	vm           *sobek.Runtime
 	currentScope *scopeState
@@ -15,7 +14,6 @@ type Registry struct {
 	el           *eventloop.EventLoop
 }
 
-// Enable registers all global intrinsics (panic, sizeof, defer/scope)
 func Enable(vm *sobek.Runtime, el *eventloop.EventLoop) *Registry {
 	r := &Registry{vm: vm, el: el}
 

--- a/bridge/intrinsics/io.go
+++ b/bridge/intrinsics/io.go
@@ -5,7 +5,6 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// JSReader wraps a JS object with a read() method into an io.Reader
 type JSReader struct {
 	vm   *sobek.Runtime
 	obj  *sobek.Object
@@ -40,7 +39,6 @@ func (r *Registry) WrapReader(call sobek.FunctionCall) sobek.Value {
 	return r.vm.ToValue(&JSReader{vm: r.vm, obj: obj, read: read})
 }
 
-// JSWriter wraps a JS object with a write() method into an io.Writer
 type JSWriter struct {
 	vm    *sobek.Runtime
 	obj   *sobek.Object

--- a/bridge/intrinsics/process.go
+++ b/bridge/intrinsics/process.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// EnableProcess injects the Node.js `process` global
 func (r *Registry) EnableProcess() {
 	proc := r.vm.NewObject()
 
@@ -33,23 +32,18 @@ func (r *Registry) EnableProcess() {
 		}
 	}
 
-	// Force color
 	_ = env.Set("FORCE_COLOR", "1")
 	_ = proc.Set("env", env)
 
-	// process.platform
 	_ = proc.Set("platform", runtime.GOOS)
 
-	// process.cwd()
 	_ = proc.Set("cwd", func(call sobek.FunctionCall) sobek.Value {
 		wd, _ := os.Getwd()
 		return r.vm.ToValue(wd)
 	})
 
-	// process.argv
 	_ = proc.Set("argv", os.Args)
 
-	// process.version
 	_ = proc.Set("version", runtime.Version())
 
 	_ = r.vm.Set("process", proc)

--- a/bridge/intrinsics/timers.go
+++ b/bridge/intrinsics/timers.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// EnableTimers injects setTimeout and setInterval globals
 func (r *Registry) EnableTimers() {
 	_ = r.vm.Set("setTimeout", func(call sobek.FunctionCall) sobek.Value {
 		fn, _ := sobek.AssertFunction(call.Argument(0))
@@ -39,7 +38,6 @@ func (r *Registry) EnableTimers() {
 		if obj != nil {
 			if ch := obj.Get("__stop__"); ch != nil {
 				if stop, ok := ch.Export().(chan struct{}); ok {
-					// Check if closed
 					select {
 					case <-stop:
 					default:
@@ -72,7 +70,6 @@ func (r *Registry) EnableTimers() {
 			}
 		}()
 
-		// Return a simple ID object for clearInterval
 		id := r.vm.NewObject()
 		_ = id.Set("__stop__", stop)
 		return id

--- a/bridge/stdlib/memory/memory.go
+++ b/bridge/stdlib/memory/memory.go
@@ -10,26 +10,22 @@ import (
 	"github.com/repyh/typego/eventloop"
 )
 
-// SharedSegment represents a named block of memory shared between Go and JS.
 type SharedSegment struct {
 	Data []byte
 	Mu   sync.RWMutex
 }
 
-// Factory manages shared memory segments for an engine instance.
 type Factory struct {
 	segments map[string]*SharedSegment
 	mu       sync.Mutex
 }
 
-// NewFactory creates a new memory factory.
 func NewFactory() *Factory {
 	return &Factory{
 		segments: make(map[string]*SharedSegment),
 	}
 }
 
-// MakeShared gets or creates a shared memory segment.
 func (f *Factory) MakeShared(name string, size int) *SharedSegment {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -43,12 +39,10 @@ func (f *Factory) MakeShared(name string, size int) *SharedSegment {
 	return s
 }
 
-// Module implements the typego:memory module.
 type Module struct {
 	Factory *Factory
 }
 
-// GetStats returns memory statistics to JS.
 func (m *Module) GetStats(vm *sobek.Runtime) func(sobek.FunctionCall) sobek.Value {
 	return func(call sobek.FunctionCall) sobek.Value {
 		var ms runtime.MemStats
@@ -64,7 +58,6 @@ func (m *Module) GetStats(vm *sobek.Runtime) func(sobek.FunctionCall) sobek.Valu
 	}
 }
 
-// Register injects the typego:memory module into the runtime.
 func Register(vm *sobek.Runtime, el *eventloop.EventLoop, f *Factory) {
 	if f == nil {
 		f = NewFactory()
@@ -96,7 +89,6 @@ func Register(vm *sobek.Runtime, el *eventloop.EventLoop, f *Factory) {
 		return res
 	})
 
-	// Ptr factory for referencing values
 	_ = obj.Set("ptr", func(call sobek.FunctionCall) sobek.Value {
 		val := call.Argument(0)
 		return val

--- a/internal/linker/fetcher.go
+++ b/internal/linker/fetcher.go
@@ -6,12 +6,10 @@ import (
 	"os/exec"
 )
 
-// Fetcher handles downloading remote Go modules
 type Fetcher struct {
 	TempDir string
 }
 
-// NewFetcher creates a new Fetcher in a temporary directory
 func NewFetcher() (*Fetcher, error) {
 	tempDir, err := os.MkdirTemp("", "typego-fetcher-*")
 	if err != nil {
@@ -28,7 +26,6 @@ func NewFetcher() (*Fetcher, error) {
 	return &Fetcher{TempDir: tempDir}, nil
 }
 
-// Get downloading a package version using 'go get'
 func (f *Fetcher) Get(pkgPath string) error {
 	cmd := exec.Command("go", "get", pkgPath)
 	cmd.Dir = f.TempDir
@@ -38,7 +35,6 @@ func (f *Fetcher) Get(pkgPath string) error {
 	return nil
 }
 
-// Cleanup removes the temporary directory
 func (f *Fetcher) Cleanup() {
 	os.RemoveAll(f.TempDir)
 }


### PR DESCRIPTION
This PR sanitizes the codebase by removing redundant, obvious, and AI-generated filler comments as requested. It touches multiple files in `bridge/` and `internal/` to ensure a cleaner and more professional codebase.

Key changes:
- Removed comments that simply restate the name of the function or type (e.g., `// Fetcher handles...`).
- Removed comments explaining basic syntax (e.g., `// Check if closed` before a select).
- Preserved all comments related to architectural decisions, thread safety (e.g., `VMLock` usage), infinite recursion prevention, and security (e.g., path sanitization).

Verified with `go test ./...`.

---
*PR created automatically by Jules for task [11707382374514411070](https://jules.google.com/task/11707382374514411070) started by @repyh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal code structure and documentation across multiple core modules including reflection, concurrency, encoding, I/O, process management, timers, and memory management
  * Enhanced validation in concurrent operations to improve error reporting and stability
  * Improved module initialization and environment setup for enhanced build tooling integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->