### PR TITLE
chore: sanitize redundant comments and AI-fluff

### DIFF
--- a/bridge/intrinsics/process.go
+++ b/bridge/intrinsics/process.go
@@ -37,19 +37,15 @@ func (r *Registry) EnableProcess() {
 	_ = env.Set("FORCE_COLOR", "1")
 	_ = proc.Set("env", env)
 
-	// process.platform
 	_ = proc.Set("platform", runtime.GOOS)
 
-	// process.cwd()
 	_ = proc.Set("cwd", func(call sobek.FunctionCall) sobek.Value {
 		wd, _ := os.Getwd()
 		return r.vm.ToValue(wd)
 	})
 
-	// process.argv
 	_ = proc.Set("argv", os.Args)
 
-	// process.version
 	_ = proc.Set("version", runtime.Version())
 
 	_ = r.vm.Set("process", proc)

--- a/bridge/intrinsics/timers.go
+++ b/bridge/intrinsics/timers.go
@@ -72,7 +72,6 @@ func (r *Registry) EnableTimers() {
 			}
 		}()
 
-		// Return a simple ID object for clearInterval
 		id := r.vm.NewObject()
 		_ = id.Set("__stop__", stop)
 		return id

--- a/bridge/modules/net/http.go
+++ b/bridge/modules/net/http.go
@@ -172,7 +172,6 @@ func Register(vm *sobek.Runtime, el *eventloop.EventLoop) {
 			panic(vm.NewGoError(err))
 		}
 
-		// Return the server for later shutdown
 		srvObj := vm.NewObject()
 		_ = srvObj.Set("close", func(call sobek.FunctionCall) sobek.Value {
 			timeout := 5 * time.Second

--- a/compiler/plugins/defer.go
+++ b/compiler/plugins/defer.go
@@ -16,7 +16,6 @@ func DeferPlugin() api.Plugin {
 		Name: "typego-defer",
 		Setup: func(build api.PluginBuild) {
 
-			// Initialize Visitors
 			core.Visitors = nil
 			core.RegisterVisitor(&visitors.DeferVisitor{})
 			core.RegisterVisitor(&visitors.IotaVisitor{})
@@ -51,7 +50,6 @@ func DeferPlugin() api.Plugin {
 					}, nil
 				}
 
-				// 4. Return to esbuild
 				return api.OnLoadResult{
 					Contents: &newCode,
 					Loader:   api.LoaderJS,

--- a/examples/projects/link-shortener/src/db/store.ts
+++ b/examples/projects/link-shortener/src/db/store.ts
@@ -1,4 +1,3 @@
-// In-memory link storage
 const links: Map<string, { url: string; clicks: number; createdAt: Date }> = new Map();
 
 export function saveLink(code: string, url: string): void {

--- a/examples/projects/link-shortener/src/handlers/links.ts
+++ b/examples/projects/link-shortener/src/handlers/links.ts
@@ -8,7 +8,6 @@ interface ShortenRequest {
 
 export function handleShorten(c: Context): void {
     const body = c.Request.Body;
-    // Parse JSON body
     let req: ShortenRequest;
     try {
         req = JSON.parse(body);

--- a/examples/projects/link-shortener/src/index.ts
+++ b/examples/projects/link-shortener/src/index.ts
@@ -98,12 +98,10 @@ function handleStats(c: Context): void {
 // === Server setup ===
 const app = Default();
 
-// Health check
 app.GET("/api/health", (c: Context) => {
     c.JSON(200, { status: "ok", service: "shortlink", links_count: links.size });
 });
 
-// Link management
 app.POST("/api/shorten", handleShorten);
 app.GET("/api/shorten", handleShorten); // Also allow GET for easy testing
 app.GET("/api/stats/:code", handleStats);

--- a/internal/ecosystem/installer/install.go
+++ b/internal/ecosystem/installer/install.go
@@ -70,7 +70,6 @@ func RunInstall(cwd string) error {
 		allUsedModules = append(allUsedModules, imports...)
 	}
 
-	// Dedup
 	usedMap := make(map[string]bool)
 	for _, m := range allUsedModules {
 		// remove "go:" prefix logic should be in Extractor or here
@@ -98,7 +97,6 @@ func RunInstall(cwd string) error {
 		return err
 	}
 
-	// Initialize go.mod in workDir
 	_ = resolver.InitGoMod(workDir, "typego_jit_build")
 
 	// Detect if we are in the typego repo (local dev) to add source replacement
@@ -183,7 +181,6 @@ func RunInstall(cwd string) error {
 	binaryPath := filepath.Join(binDir, BinaryName)
 	fmt.Println("✅ Install Complete! Binary cached at", binaryPath)
 
-	// Ensure .typego is ignored
 	_ = ecosystem.EnsureGitIgnore(cwd)
 
 	// Write checksum for stale detection
@@ -194,7 +191,6 @@ func RunInstall(cwd string) error {
 	// Generate lockfile from resolved go.mod
 	writeLockfile(cwd, workDir, config.Dependencies)
 
-	// Auto-generate types
 	if len(packageInfos) > 0 {
 		fmt.Println("📦 Syncing type definitions...")
 		writeTypeDefinitions(cwd, packageInfos)

--- a/internal/linker/fetcher.go
+++ b/internal/linker/fetcher.go
@@ -18,7 +18,6 @@ func NewFetcher() (*Fetcher, error) {
 		return nil, err
 	}
 
-	// Initialize a dummy module to hold dependencies
 	cmd := exec.Command("go", "mod", "init", "typego-dummy")
 	cmd.Dir = tempDir
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/internal/linker/inspector.go
+++ b/internal/linker/inspector.go
@@ -106,9 +106,8 @@ func goToTSTypeWithContext(goType string, knownStructs map[string]bool) string {
 		}
 		// Check if it's a known struct from this package
 		if knownStructs != nil && knownStructs[goType] {
-			return goType // Return as-is, it will reference the interface
+			return goType
 		}
-		// Return the type name (may be a struct from this package)
 		return goType
 	}
 }

--- a/pkg/cli/pkg/update.go
+++ b/pkg/cli/pkg/update.go
@@ -37,7 +37,6 @@ Examples:
 			return
 		}
 
-		// If specific module provided, update only that
 		if len(args) > 0 {
 			module := args[0]
 			if _, ok := config.Dependencies[module]; !ok {
@@ -60,7 +59,6 @@ Examples:
 
 			internal.Success(fmt.Sprintf("Updated %s to %s", module, latestVersion))
 		} else {
-			// Update all
 			internal.Step("🔄", "Updating all dependencies...")
 			updated := 0
 
@@ -96,17 +94,14 @@ Examples:
 
 // getLatestVersion queries go list to get the latest version of a module
 func getLatestVersion(module string) (string, error) {
-	// Create temp dir for go list
 	tmpDir := filepath.Join(os.TempDir(), "typego-update-check")
 	_ = os.MkdirAll(tmpDir, 0755)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	// Initialize a dummy go.mod
 	initCmd := exec.Command("go", "mod", "init", "temp")
 	initCmd.Dir = tmpDir
 	_ = initCmd.Run()
 
-	// Query latest version
 	cmd := exec.Command("go", "list", "-m", "-versions", module)
 	cmd.Dir = tmpDir
 	output, err := cmd.Output()
@@ -120,10 +115,8 @@ func getLatestVersion(module string) (string, error) {
 		return "latest", nil
 	}
 
-	// Return the last version (most recent)
 	return parts[len(parts)-1], nil
 }
 
 func init() {
-	// Add to subcommand of typego if needed
 }


### PR DESCRIPTION
Performed a comment audit to remove redundant, obvious, and AI-generated filler comments across the repository. This includes Go files in `bridge/`, `pkg/`, `internal/`, and `compiler/`, as well as TypeScript examples. Preserved essential documentation and architectural explanations.


---
*PR created automatically by Jules for task [6291628597624106931](https://jules.google.com/task/6291628597624106931) started by @repyh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed inline comments throughout codebase for improved code clarity.

* **Bug Fixes**
  * Removed the health check endpoint from the link-shortener example project.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->