### PR TITLE
chore: sanitize redundant comments and AI-fluff

### DIFF
--- a/bridge/core/reflection.go
+++ b/bridge/core/reflection.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// Binding represents a Go struct that has been bound to the JavaScript runtime.
 type Binding struct {
 	Name   string
 	Target interface{}
@@ -27,10 +26,8 @@ type fieldInfo struct {
 	Anonymous bool
 }
 
-// cache for struct method metadata: reflect.Type -> []methodInfo
 var typeMethodCache sync.Map
 
-// cache for struct field metadata: reflect.Type -> []fieldInfo
 var typeFieldCache sync.Map
 
 // BindStruct exposes a Go struct to JavaScript with full field and method access.
@@ -43,7 +40,6 @@ func BindStruct(vm *sobek.Runtime, name string, s interface{}) error {
 	return vm.GlobalObject().Set(name, obj)
 }
 
-// bindValue recursively converts a Go value to a JavaScript value.
 // The visited map prevents infinite loops for circular references.
 func bindValue(vm *sobek.Runtime, v reflect.Value, visited map[uintptr]sobek.Value) (sobek.Value, error) {
 	if !v.IsValid() {
@@ -317,7 +313,6 @@ func wrapJSCallback(vm *sobek.Runtime, callable sobek.Callable, goType reflect.T
 			return results
 		}
 
-		// Convert result back to Go
 		numOut := goType.NumOut()
 		if numOut == 0 {
 			return nil

--- a/bridge/intrinsics/concurrency.go
+++ b/bridge/intrinsics/concurrency.go
@@ -27,7 +27,6 @@ func (r *Registry) Go(call sobek.FunctionCall) sobek.Value {
 			}
 		}()
 
-		// Execute the function in the VM
 		// NOTE: Sobek is NOT thread-safe for concurrent access to the SAME VM.
 		// We use the Registry's VMLock to ensure only one goroutine (or main thread) executes JS at a time.
 		r.VMLock.Lock()
@@ -68,7 +67,6 @@ func (c *Chan) Close(call sobek.FunctionCall) sobek.Value {
 	return sobek.Undefined()
 }
 
-// MakeChan implements makeChan(size)
 func (r *Registry) MakeChan(call sobek.FunctionCall) sobek.Value {
 	size := 0
 	if len(call.Arguments) > 0 {
@@ -104,7 +102,6 @@ func (r *Registry) Select(call sobek.FunctionCall) sobek.Value {
 		caseObj := casesArr.Get(fmt.Sprintf("%d", i)).ToObject(r.vm)
 		caseObjs = append(caseObjs, caseObj)
 
-		// 1. Default case
 		if defValue := caseObj.Get("default"); defValue != nil && !sobek.IsUndefined(defValue) {
 			selectCases = append(selectCases, reflect.SelectCase{
 				Dir: reflect.SelectDefault,
@@ -112,7 +109,6 @@ func (r *Registry) Select(call sobek.FunctionCall) sobek.Value {
 			continue
 		}
 
-		// 2. Channel operation
 		chWrapper := caseObj.Get("chan")
 		if chWrapper == nil || sobek.IsUndefined(chWrapper) {
 			continue
@@ -131,7 +127,6 @@ func (r *Registry) Select(call sobek.FunctionCall) sobek.Value {
 
 		chValue := reflect.ValueOf(c.ch)
 
-		// Determine Direction
 		if sendVal := caseObj.Get("send"); sendVal != nil && !sobek.IsUndefined(sendVal) {
 			selectCases = append(selectCases, reflect.SelectCase{
 				Dir:  reflect.SelectSend,
@@ -157,7 +152,6 @@ func (r *Registry) Select(call sobek.FunctionCall) sobek.Value {
 
 	chosenObj := caseObjs[chosen]
 
-	// Handle Result
 	if selectCases[chosen].Dir == reflect.SelectRecv {
 		recvVal := recv.Interface().(sobek.Value)
 		if recvCb := chosenObj.Get("recv"); recvCb != nil && !sobek.IsUndefined(recvCb) {

--- a/bridge/intrinsics/encoding.go
+++ b/bridge/intrinsics/encoding.go
@@ -6,9 +6,6 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// Encoding intrinsics provide high-performance string/byte conversion.
-
-// Encode implements TextEncoder.prototype.encode
 func (r *Registry) Encode(call sobek.FunctionCall) sobek.Value {
 	var bytes []byte
 	if len(call.Arguments) > 0 {
@@ -26,7 +23,6 @@ func (r *Registry) Encode(call sobek.FunctionCall) sobek.Value {
 	return tArray
 }
 
-// Decode implements TextDecoder.prototype.decode
 func (r *Registry) Decode(call sobek.FunctionCall) sobek.Value {
 	if len(call.Arguments) == 0 {
 		return r.vm.ToValue("")
@@ -58,7 +54,6 @@ func (r *Registry) Decode(call sobek.FunctionCall) sobek.Value {
 	}
 
 	if !utf8.Valid(bytes) {
-		// Handle non-UTF8? For now just try to convert.
 		return r.vm.ToValue(string(bytes))
 	}
 

--- a/bridge/intrinsics/timers.go
+++ b/bridge/intrinsics/timers.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// EnableTimers injects setTimeout and setInterval globals
 func (r *Registry) EnableTimers() {
 	_ = r.vm.Set("setTimeout", func(call sobek.FunctionCall) sobek.Value {
 		fn, _ := sobek.AssertFunction(call.Argument(0))
@@ -39,7 +38,6 @@ func (r *Registry) EnableTimers() {
 		if obj != nil {
 			if ch := obj.Get("__stop__"); ch != nil {
 				if stop, ok := ch.Export().(chan struct{}); ok {
-					// Check if closed
 					select {
 					case <-stop:
 					default:
@@ -72,7 +70,6 @@ func (r *Registry) EnableTimers() {
 			}
 		}()
 
-		// Return a simple ID object for clearInterval
 		id := r.vm.NewObject()
 		_ = id.Set("__stop__", stop)
 		return id

--- a/bridge/modules/net/http.go
+++ b/bridge/modules/net/http.go
@@ -172,7 +172,6 @@ func Register(vm *sobek.Runtime, el *eventloop.EventLoop) {
 			panic(vm.NewGoError(err))
 		}
 
-		// Return the server for later shutdown
 		srvObj := vm.NewObject()
 		_ = srvObj.Set("close", func(call sobek.FunctionCall) sobek.Value {
 			timeout := 5 * time.Second

--- a/bridge/modules/net/server.go
+++ b/bridge/modules/net/server.go
@@ -37,7 +37,6 @@ func (s *Server) ListenAndServe(addr string, handler sobek.Callable) error {
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  60 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Create JS Request and Response wrappers
 			req := s.wrapRequest(r)
 			res := s.wrapResponse(w, r)
 
@@ -45,19 +44,16 @@ func (s *Server) ListenAndServe(addr string, handler sobek.Callable) error {
 
 			s.el.RunOnLoop(func() {
 				defer close(done)
-				// Call the JS handler with (req, res)
 				_, err := handler(sobek.Undefined(), req, res)
 				if err != nil {
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				}
 			})
 
-			// Wait for handler to complete
 			<-done
 		}),
 	}
 
-	// Start server in background
 	s.el.WGAdd(1)
 	go func() {
 		defer s.el.WGDone()
@@ -85,14 +81,12 @@ func (s *Server) Close(timeout time.Duration) error {
 func (s *Server) wrapRequest(r *http.Request) sobek.Value {
 	req := s.vm.NewObject()
 
-	// Basic properties
 	_ = req.Set("method", r.Method)
 	_ = req.Set("url", r.URL.String())
 	_ = req.Set("path", r.URL.Path)
 	_ = req.Set("host", r.Host)
 	_ = req.Set("proto", r.Proto)
 
-	// Query parameters
 	query := s.vm.NewObject()
 	for k, v := range r.URL.Query() {
 		if len(v) == 1 {
@@ -103,7 +97,6 @@ func (s *Server) wrapRequest(r *http.Request) sobek.Value {
 	}
 	_ = req.Set("query", query)
 
-	// Headers
 	headers := s.vm.NewObject()
 	for k, v := range r.Header {
 		if len(v) == 1 {
@@ -171,7 +164,6 @@ func (s *Server) wrapResponse(w http.ResponseWriter, r *http.Request) sobek.Valu
 		return res // Chainable
 	})
 
-	// Send response and end
 	_ = res.Set("send", func(call sobek.FunctionCall) sobek.Value {
 		if !headersSent {
 			w.WriteHeader(statusCode)
@@ -184,7 +176,6 @@ func (s *Server) wrapResponse(w http.ResponseWriter, r *http.Request) sobek.Valu
 		return sobek.Undefined()
 	})
 
-	// Send JSON response
 	_ = res.Set("json", func(call sobek.FunctionCall) sobek.Value {
 		w.Header().Set("Content-Type", "application/json")
 		if !headersSent {
@@ -202,7 +193,6 @@ func (s *Server) wrapResponse(w http.ResponseWriter, r *http.Request) sobek.Valu
 		return sobek.Undefined()
 	})
 
-	// Redirect
 	_ = res.Set("redirect", func(call sobek.FunctionCall) sobek.Value {
 		url := call.Argument(0).String()
 		code := 302

--- a/bridge/stdlib/memory/memory.go
+++ b/bridge/stdlib/memory/memory.go
@@ -22,7 +22,6 @@ type Factory struct {
 	mu       sync.Mutex
 }
 
-// NewFactory creates a new memory factory.
 func NewFactory() *Factory {
 	return &Factory{
 		segments: make(map[string]*SharedSegment),
@@ -43,12 +42,10 @@ func (f *Factory) MakeShared(name string, size int) *SharedSegment {
 	return s
 }
 
-// Module implements the typego:memory module.
 type Module struct {
 	Factory *Factory
 }
 
-// GetStats returns memory statistics to JS.
 func (m *Module) GetStats(vm *sobek.Runtime) func(sobek.FunctionCall) sobek.Value {
 	return func(call sobek.FunctionCall) sobek.Value {
 		var ms runtime.MemStats
@@ -64,7 +61,6 @@ func (m *Module) GetStats(vm *sobek.Runtime) func(sobek.FunctionCall) sobek.Valu
 	}
 }
 
-// Register injects the typego:memory module into the runtime.
 func Register(vm *sobek.Runtime, el *eventloop.EventLoop, f *Factory) {
 	if f == nil {
 		f = NewFactory()
@@ -96,7 +92,6 @@ func Register(vm *sobek.Runtime, el *eventloop.EventLoop, f *Factory) {
 		return res
 	})
 
-	// Ptr factory for referencing values
 	_ = obj.Set("ptr", func(call sobek.FunctionCall) sobek.Value {
 		val := call.Argument(0)
 		return val

--- a/internal/linker/fetcher.go
+++ b/internal/linker/fetcher.go
@@ -6,12 +6,10 @@ import (
 	"os/exec"
 )
 
-// Fetcher handles downloading remote Go modules
 type Fetcher struct {
 	TempDir string
 }
 
-// NewFetcher creates a new Fetcher in a temporary directory
 func NewFetcher() (*Fetcher, error) {
 	tempDir, err := os.MkdirTemp("", "typego-fetcher-*")
 	if err != nil {
@@ -28,7 +26,6 @@ func NewFetcher() (*Fetcher, error) {
 	return &Fetcher{TempDir: tempDir}, nil
 }
 
-// Get downloading a package version using 'go get'
 func (f *Fetcher) Get(pkgPath string) error {
 	cmd := exec.Command("go", "get", pkgPath)
 	cmd.Dir = f.TempDir
@@ -38,7 +35,6 @@ func (f *Fetcher) Get(pkgPath string) error {
 	return nil
 }
 
-// Cleanup removes the temporary directory
 func (f *Fetcher) Cleanup() {
 	os.RemoveAll(f.TempDir)
 }

--- a/pkg/cli/cmd/types.go
+++ b/pkg/cli/cmd/types.go
@@ -32,7 +32,6 @@ var TypesCmd = &cobra.Command{
 			return
 		}
 
-		// Read existing (target) file first
 		var currentContent []byte
 		if existing, err := os.ReadFile(dtsPath); err == nil && len(existing) > 0 {
 			currentContent = existing
@@ -47,7 +46,6 @@ var TypesCmd = &cobra.Command{
 		} else if len(currentContent) == 0 {
 			currentContent = []byte(newGlobal)
 		} else {
-			// Prepend if not found
 			currentContent = append([]byte(newGlobal+"\n"), currentContent...)
 		}
 
@@ -58,14 +56,11 @@ var TypesCmd = &cobra.Command{
 		}
 		defer fetcher.Cleanup()
 
-		// Collect all TypeScript files to scan (deduplicated)
 		fileSet := make(map[string]bool)
 		if len(args) > 0 {
-			// Explicit file provided
 			absPath, _ := filepath.Abs(args[0])
 			fileSet[absPath] = true
 		} else {
-			// Recursively find all .ts files in the current project
 			err := filepath.WalkDir(".", func(path string, d os.DirEntry, err error) error {
 				if err != nil {
 					return err
@@ -80,7 +75,6 @@ var TypesCmd = &cobra.Command{
 					return nil
 				}
 
-				// Only collect .ts files
 				if filepath.Ext(path) == ".ts" {
 					absPath, _ := filepath.Abs(path)
 					fileSet[absPath] = true
@@ -92,7 +86,6 @@ var TypesCmd = &cobra.Command{
 			}
 		}
 
-		// Collect unique Go imports from all files
 		goImports := make(map[string]bool)
 
 		// FORCE: Always include core modules that need inspection
@@ -213,7 +206,6 @@ var TypesCmd = &cobra.Command{
 }
 
 func init() {
-	// Registered in root.go
 }
 
 func updateTypeBlock(content []byte, moduleName, typeDef string) []byte {

--- a/pkg/cli/pkg/update.go
+++ b/pkg/cli/pkg/update.go
@@ -37,7 +37,6 @@ Examples:
 			return
 		}
 
-		// If specific module provided, update only that
 		if len(args) > 0 {
 			module := args[0]
 			if _, ok := config.Dependencies[module]; !ok {
@@ -60,7 +59,6 @@ Examples:
 
 			internal.Success(fmt.Sprintf("Updated %s to %s", module, latestVersion))
 		} else {
-			// Update all
 			internal.Step("🔄", "Updating all dependencies...")
 			updated := 0
 
@@ -94,19 +92,15 @@ Examples:
 	},
 }
 
-// getLatestVersion queries go list to get the latest version of a module
 func getLatestVersion(module string) (string, error) {
-	// Create temp dir for go list
 	tmpDir := filepath.Join(os.TempDir(), "typego-update-check")
 	_ = os.MkdirAll(tmpDir, 0755)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	// Initialize a dummy go.mod
 	initCmd := exec.Command("go", "mod", "init", "temp")
 	initCmd.Dir = tmpDir
 	_ = initCmd.Run()
 
-	// Query latest version
 	cmd := exec.Command("go", "list", "-m", "-versions", module)
 	cmd.Dir = tmpDir
 	output, err := cmd.Output()
@@ -120,10 +114,8 @@ func getLatestVersion(module string) (string, error) {
 		return "latest", nil
 	}
 
-	// Return the last version (most recent)
 	return parts[len(parts)-1], nil
 }
 
 func init() {
-	// Add to subcommand of typego if needed
 }


### PR DESCRIPTION
Performed a repository-wide comment audit to remove redundant and AI-generated filler comments.

Key changes:
- `bridge/intrinsics/concurrency.go`: Removed obvious channel operation comments.
- `bridge/intrinsics/timers.go`: Removed redundant timer logic comments.
- `bridge/intrinsics/encoding.go`: Removed trivial TextEncoder/Decoder comments.
- `bridge/core/reflection.go`: Removed redundant struct/field caching comments.
- `bridge/modules/net/http.go` & `server.go`: Removed obvious HTTP handler/wrapper comments.
- `pkg/cli/cmd/types.go` & `pkg/cli/pkg/update.go`: Removed obvious step descriptions in CLI commands.
- `bridge/stdlib/memory/memory.go`: Removed trivial factory/module comments.
- `internal/linker/fetcher.go`: Removed obvious struct/method comments.

Verified via `go test ./...` and manual inspection.

---
*PR created automatically by Jules for task [13632510546583784319](https://jules.google.com/task/13632510546583784319) started by @repyh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting and diagnostics during dependency fetching operations.

* **Chores**
  * Removed internal caches and documentation comments throughout the codebase for streamlined maintenance.
  * Updated type generation initialization to optimize file handling behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->